### PR TITLE
fix circular import by relocating eval_hooks

### DIFF
--- a/det3d/core/evaluation/__init__.py
+++ b/det3d/core/evaluation/__init__.py
@@ -7,7 +7,6 @@ from .class_names import (
     voc_classes,
 )
 from .coco_utils import coco_eval, fast_eval_recall, results2json
-from .eval_hooks import KittiDistEvalmAPHook, KittiEvalmAPHookV2
 from .mean_ap import average_precision, eval_map, print_map_summary
 from .recall import eval_recalls, plot_iou_recall, plot_num_recall, print_recall_summary
 
@@ -21,8 +20,6 @@ __all__ = [
     "coco_eval",
     "fast_eval_recall",
     "results2json",
-    "KittiDistEvalmAPHook",
-    "KittiEvalmAPHookV2",
     "average_precision",
     "eval_map",
     "print_map_summary",

--- a/det3d/datasets/kitti/eval_hooks.py
+++ b/det3d/datasets/kitti/eval_hooks.py
@@ -17,8 +17,7 @@ from det3d.utils.dist.dist_common import (
 from pycocotools.cocoeval import COCOeval
 from torch.utils.data import Dataset
 
-from .coco_utils import fast_eval_recall, results2json
-from .mean_ap import eval_map
+from det3d.core import fast_eval_recall, results2json, eval_map
 
 
 class KittiDistEvalmAPHook(Hook):

--- a/det3d/torchie/apis/train.py
+++ b/det3d/torchie/apis/train.py
@@ -9,7 +9,7 @@ import numpy as np
 import torch
 from det3d.builder import _create_learning_rate_scheduler
 
-# from det3d.core.evaluation import KittiDistEvalmAPHook, KittiEvalmAPHookV2
+# from det3d.datasets.kitti.eval_hooks import KittiDistEvalmAPHook, KittiEvalmAPHookV2
 from det3d.core import DistOptimizerHook
 from det3d.datasets import DATASETS, build_dataloader
 from det3d.solver.fastai_optim import OptimWrapper

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,9 +8,6 @@ no_lines_before=STDLIB,THIRDPARTY
 sections=FUTURE,STDLIB,THIRDPARTY,myself,FIRSTPARTY,LOCALFOLDER
 default_section=FIRSTPARTY
 
-[easy_install]
-index_url=https://pypi.douban.com/simple/
-
 [flake8]
 ignore = W503, E203, E221, E402, E741, C901, W504, E731
 max-line-length = 100


### PR DESCRIPTION
Fixes #14. The KittiEvalHooks seem to be legacy code and maybe can be deleted altogether? It seems eval is now done through trainer's `val` method.