### PR TITLE
Fix bug in kitti eval

### DIFF
--- a/det3d/datasets/kitti/eval.py
+++ b/det3d/datasets/kitti/eval.py
@@ -513,7 +513,7 @@ def get_official_eval_result(
     # TODO dt2gt
     metrics = do_eval_v3(
         gt_annos,
-        gt_annos,
+        dt_annos,
         current_classes,
         min_overlaps,
         compute_aos,

--- a/det3d/datasets/kitti/kitti_common.py
+++ b/det3d/datasets/kitti/kitti_common.py
@@ -1,5 +1,6 @@
 import pathlib
 import pickle
+import re
 import numpy as np
 
 from collections import OrderedDict

--- a/det3d/datasets/utils/eval.py
+++ b/det3d/datasets/utils/eval.py
@@ -192,7 +192,7 @@ def compute_statistics_jit(
                 continue
             if ignored_threshold[j]:
                 continue
-            overlap = overlaps[i, j]
+            overlap = overlaps[j, i]
             dt_score = dt_scores[j]
             if (
                 not compute_fp

--- a/det3d/datasets/utils/kitti_object_eval_python/evaluate.py
+++ b/det3d/datasets/utils/kitti_object_eval_python/evaluate.py
@@ -1,7 +1,7 @@
 import time
 import fire
 
-from det3d.datasets import kitti
+from det3d.datasets.kitti import kitti_common as kitti
 from .eval import get_official_eval_result, get_coco_eval_result
 
 


### PR DESCRIPTION
KITTI evaluation has some bugs and the evaluation results are strange as follows:

Evaluation official: car AP(Average Precision)@0.70, 0.70, 0.70:
bbox AP:100.00, 100.00, 100.00
bev  AP:0.10, 0.14, 0.23
3d   AP:0.10, 0.14, 0.23
aos  AP:100.00, 100.00, 100.00
car AP(Average Precision)@0.70, 0.50, 0.50:
bbox AP:100.00, 100.00, 100.00
bev  AP:0.10, 0.14, 0.23
3d   AP:0.10, 0.14, 0.23
aos  AP:100.00, 100.00, 100.00

This PR fixed the bugs, which were related to #16 .