### PR TITLE
fix bug due to linspace float argument

### DIFF
--- a/det3d/datasets/kitti/eval.py
+++ b/det3d/datasets/kitti/eval.py
@@ -428,7 +428,8 @@ def do_coco_style_eval(
     min_overlaps = np.zeros([10, *overlap_ranges.shape[1:]])
     for i in range(overlap_ranges.shape[1]):
         for j in range(overlap_ranges.shape[2]):
-            min_overlaps[:, i, j] = np.linspace(*overlap_ranges[:, i, j])
+            start, stop, num = overlap_ranges[:, i, j]
+            min_overlaps[:, i, j] = np.linspace(start, stop, int(num))
     mAP_bbox, mAP_bev, mAP_3d, mAP_aos = do_eval_v2(
         gt_annos,
         dt_annos,


### PR DESCRIPTION
Latest `numpy 1.18.0` no longer supports float as third argument in `np.linspace` (and this support has been [deprecated](https://numpy.org/devdocs/release/1.12.0-notes.html#deprecations) for a while). This PR fixes the following bug when using latest `numpy`:

```
File "/usr/local/lib/python3.6/dist-packages/numpy/core/function_base.py", line 117, in linspace
  num = operator.index(num)
TypeError: 'numpy.float64' object cannot be interpreted as an integer

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "./tools/train.py", line 133, in <module>
    main()
  File "./tools/train.py", line 128, in main
    logger=logger,
  File "/root/det3d/det3d/torchie/apis/train.py", line 343, in train_detector
    trainer.run(data_loaders, cfg.workflow, cfg.total_epochs, local_rank=cfg.local_rank)
  File "/root/det3d/det3d/torchie/trainer/trainer.py", line 534, in run
    epoch_runner(data_loaders[i], **kwargs)
  File "/root/det3d/det3d/torchie/trainer/trainer.py", line 466, in val
    predictions, output_dir=self.work_dir
  File "/root/det3d/det3d/datasets/kitti/kitti.py", line 178, in evaluation
    gt_annos, dt_annos, self._class_names, z_axis=z_axis, z_center=z_center
  File "/root/det3d/det3d/datasets/kitti/eval.py", line 629, in get_coco_eval_result
    z_center=z_center,
  File "/root/det3d/det3d/datasets/kitti/eval.py", line 431, in do_coco_style_eval
    min_overlaps[:, i, j] = np.linspace(*overlap_ranges[:, i, j])
  File "<__array_function__ internals>", line 6, in linspace
  File "/usr/local/lib/python3.6/dist-packages/numpy/core/function_base.py", line 121, in linspace
    .format(type(num)))
TypeError: object of type <class 'numpy.float64'> cannot be safely interpreted as an integer.
```