### PR TITLE
fix map_location bug device specification bug

### DIFF
--- a/det3d/torchie/trainer/trainer.py
+++ b/det3d/torchie/trainer/trainer.py
@@ -475,7 +475,7 @@ class Trainer(object):
     def resume(self, checkpoint, resume_optimizer=True, map_location="default"):
         if map_location == "default":
             checkpoint = self.load_checkpoint(
-                checkpoint, map_location=torch.cuda.current_device()
+                checkpoint, map_location=torch.device(torch.cuda.current_device())
             )
         else:
             checkpoint = self.load_checkpoint(checkpoint, map_location=map_location)


### PR DESCRIPTION
`map_location` argument in `torch.load` cannot be given as an integer (i.e. `0` must instead be written as `'cuda:0'`). See [docs](https://pytorch.org/docs/stable/torch.html#torch.load). Currently, restoring model using `resume_from` argument in `train.py` results in:

```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/jhultman/.miniconda3/envs/det3d/lib/python3.6/site-packages/torch/serialization.py", line 426, in load
    return _load(f, map_location, pickle_module, **pickle_load_args)
  File "/home/jhultman/.miniconda3/envs/det3d/lib/python3.6/site-packages/torch/serialization.py", line 613, in _load
    result = unpickler.load()
  File "/home/jhultman/.miniconda3/envs/det3d/lib/python3.6/site-packages/torch/serialization.py", line 576, in persistent_load
    deserialized_objects[root_key] = restore_location(obj, location)
  File "/home/jhultman/.miniconda3/envs/det3d/lib/python3.6/site-packages/torch/serialization.py", line 449, in restore_location
    result = map_location(storage, location)
TypeError: 'int' object is not callable
```