### PR TITLE
bug fix: update the path of lyft_info_*.pkl

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Please refer to [INSTALL.md](INSTALL.md).
 
 ## Quick Start
 
-Please refer to [GETTING_START.md](GETTING_START.md).
+Please refer to [GETTING_STARTED.md](GETTING_STARTED.md).
 
 ## Model Zoo and Baselines
 

--- a/det3d/datasets/lyft/lyft_common.py
+++ b/det3d/datasets/lyft/lyft_common.py
@@ -191,12 +191,12 @@ def create_lyft_infos(root_path, version="trainval"):
 
     if test:
         print(f"test sample: {len(train_lyft_infos)}")
-        with open(data_path / "lyft_info_test.pkl", "wb") as f:
+        with open(root_path / "lyft_info_test.pkl", "wb") as f:
             pickle.dump(train_lyft_infos, f)
     else:
         print(f"train sample: {len(train_lyft_infos)}")
         print(f"val sample: {len(val_lyft_infos)}")
-        with open(data_path / "lyft_info_train.pkl", "wb") as f:
+        with open(root_path / "lyft_info_train.pkl", "wb") as f:
             pickle.dump(train_lyft_infos, f)
-        with open(data_path / "lyft_info_val.pkl", "wb") as f:
+        with open(root_path / "lyft_info_val.pkl", "wb") as f:
             pickle.dump(val_lyft_infos, f)


### PR DESCRIPTION
writing *lyft_info_*.pkl* in the subdirs (e.g. LYFT_ROOT/trainval/) will cause error in *create_groundtruth_database* function