### PR TITLE
improve baselines  Closes #55, Closes #47, Closes #80, Closes #117 

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,34 @@ Please refer to [GETTING_STARTED.md](GETTING_STARTED.md).
 
 ## Model Zoo and Baselines
 
-### [CBGS](https://github.com/poodarchu/Det3D/blob/master/examples/cbgs/configs/nusc_all_vfev3_spmiddleresnetfhd_rpn2_mghead_syncbn.py)
-Model checkpoint, training log and prediction results have been provided, please check [CBGS README](https://github.com/poodarchu/Det3D/tree/master/examples/cbgs) for details.
+### [CBGS](https://github.com/poodarchu/Det3D/blob/master/examples/cbgs/configs/nusc_all_vfev3_spmiddleresnetfhd_rpn2_mghead_syncbn.py) on nuScenes(val) Dataset
+
+```
+mAP: 0.4990
+mATE: 0.3353
+mASE: 0.2563
+mAOE: 0.3230
+mAVE: 0.2505
+mAAE: 0.1969
+NDS: 0.6133
+```
+
+This new model uses a voxel size of (0.1m, 0.1m, 0.2m). The model checkpoint, trianing log and predictions results are available [here](https://drive.google.com/drive/folders/1rhamAqegE9iOp18tzQVam4rOMhHjjnRM?usp=sharing).
+The original model and prediction files are available in the [CBGS README](https://github.com/poodarchu/Det3D/tree/master/examples/cbgs).
+
+### [PointPillars](examples/point_pillars/configs/nusc_all_point_pillars_mghead_syncbn.py) on nuScenes(val) Dataset
+
+```
+mAP: 0.4179
+mATE: 0.3630
+mASE: 0.2636
+mAOE: 0.3770
+mAVE: 0.2877
+mAAE: 0.1983
+NDS: 0.5600
+```
+
+The checkpoint, log and prediction files are available [here](https://drive.google.com/drive/folders/1U0bkEQAhcxhDUD42nTCGC0uU0qaTO_Uv?usp=sharing). 
 
 ### [Second](examples/second/configs/kitti_car_vfev3_spmiddlefhd_rpn1_mghead_syncbn.py) on KITTI(val) Dataset
 
@@ -51,9 +77,7 @@ aos  AP:90.48, 88.36, 86.58
 
 ### To Be Released
 
-1. [PointPillars](examples/point_pillars/configs/nusc_all_point_pillars_mghead_syncbn.py) on NuScenes(val) Dataset
-2. [CGBS](examples/cbgs/configs/nusc_all_vfev3_spmiddleresnetfhd_rpn2_mghead_syncbn.py) on NuScenes(val) Dataset
-3. [CGBS](examples/cbgs/configs/lyft_all_vfev3_spmiddleresnetfhd_rpn2_mghead_syncbn.py) on Lyft(val) Dataset
+1. [CGBS](examples/cbgs/configs/lyft_all_vfev3_spmiddleresnetfhd_rpn2_mghead_syncbn.py) on Lyft(val) Dataset
 
 ## Currently Support
 

--- a/det3d/core/anchor/target_assigner.py
+++ b/det3d/core/anchor/target_assigner.py
@@ -93,7 +93,7 @@ class TargetAssigner:
                 prune_anchor_fn = None
 
             targets = create_target_np(
-                anchor_dict["anchors"].reshape(-1, self.box_coder.code_size),
+                anchor_dict["anchors"].reshape(-1, self.box_coder.n_dim),  # to work with the angle vector encoding 
                 gt_boxes[mask],
                 similarity_fn,
                 box_encoding_fn,

--- a/det3d/core/sampler/preprocess.py
+++ b/det3d/core/sampler/preprocess.py
@@ -826,6 +826,34 @@ def random_flip(gt_boxes, points, probability=0.5):
     return gt_boxes, points
 
 
+def random_flip_both(gt_boxes, points, probability=0.5):
+    # x flip 
+    enable = np.random.choice(
+        [False, True], replace=False, p=[1 - probability, probability]
+    )
+    if enable:
+        gt_boxes[:, 1] = -gt_boxes[:, 1]
+        gt_boxes[:, -1] = -gt_boxes[:, -1] + np.pi
+        points[:, 1] = -points[:, 1]
+        if gt_boxes.shape[1] > 7:  
+            gt_boxes[:, 7] = -gt_boxes[:, 7]
+
+    # y flip 
+    enable = np.random.choice(
+        [False, True], replace=False, p=[1 - probability, probability]
+    )
+    if enable:
+        gt_boxes[:, 0] = -gt_boxes[:, 0]
+        points[:, 0] = -points[:, 0]
+
+        gt_boxes[:, -1] = -gt_boxes[:, -1] + 2*np.pi  
+
+        if gt_boxes.shape[1] > 7: 
+            gt_boxes[:, 6] = -gt_boxes[:, 6]
+
+    return gt_boxes, points
+
+
 def global_scaling_v2(gt_boxes, points, min_scale=0.95, max_scale=1.05):
     noise_scale = np.random.uniform(min_scale, max_scale)
     points[:, :3] *= noise_scale

--- a/det3d/datasets/nuscenes/nusc_common.py
+++ b/det3d/datasets/nuscenes/nusc_common.py
@@ -510,6 +510,9 @@ def _fill_trainval_infos(nusc, train_scenes, val_scenes, test=False, nsweeps=10)
                 nusc.get("sample_annotation", token) for token in sample["anns"]
             ]
 
+            # the filtering gives 0.5~1 map improvement 
+            mask = np.array([(anno['num_lidar_pts'] + anno['num_radar_pts'])>0 for anno in annotations], dtype=bool).reshape(-1)
+
             locs = np.array([b.center for b in ref_boxes]).reshape(-1, 3)
             dims = np.array([b.wlh for b in ref_boxes]).reshape(-1, 3)
             # rots = np.array([b.orientation.yaw_pitch_roll[0] for b in ref_boxes]).reshape(-1, 1)
@@ -526,10 +529,10 @@ def _fill_trainval_infos(nusc, train_scenes, val_scenes, test=False, nsweeps=10)
 
             assert len(annotations) == len(gt_boxes) == len(velocity)
 
-            info["gt_boxes"] = gt_boxes
-            info["gt_boxes_velocity"] = velocity
-            info["gt_names"] = np.array([general_to_detection[name] for name in names])
-            info["gt_boxes_token"] = tokens
+            info["gt_boxes"] = gt_boxes[mask, :]
+            info["gt_boxes_velocity"] = velocity[mask, :]
+            info["gt_names"] = np.array([general_to_detection[name] for name in names])[mask]
+            info["gt_boxes_token"] = tokens[mask]
 
         if sample["scene_token"] in train_scenes:
             train_nusc_infos.append(info)
@@ -602,7 +605,7 @@ def create_nuscenes_infos_test(root_path, version="v1.0-trainval", nsweeps=10):
     if test:
         print(f"test sample: {len(train_nusc_infos)}")
         with open(
-            root_path / "infos_test_{:02d}sweeps_withvelo.pkl".format(nsweeps), "wb"
+            root_path / "infos_test_{:02d}sweeps_withvelo_filter_True.pkl".format(nsweeps), "wb"
         ) as f:
             pickle.dump(train_nusc_infos, f)
     else:
@@ -610,11 +613,11 @@ def create_nuscenes_infos_test(root_path, version="v1.0-trainval", nsweeps=10):
             f"train sample: {len(train_nusc_infos)}, val sample: {len(val_nusc_infos)}"
         )
         with open(
-            root_path / "infos_train_{:02d}sweeps_withvelo.pkl".format(nsweeps), "wb"
+            root_path / "infos_train_{:02d}sweeps_withvelo_filter_True.pkl".format(nsweeps), "wb"
         ) as f:
             pickle.dump(train_nusc_infos, f)
         with open(
-            root_path / "infos_val_{:02d}sweeps_withvelo.pkl".format(nsweeps), "wb"
+            root_path / "infos_val_{:02d}sweeps_withvelo_filter_True.pkl".format(nsweeps), "wb"
         ) as f:
             pickle.dump(val_nusc_infos, f)
 
@@ -664,7 +667,7 @@ def create_nuscenes_infos(root_path, version="v1.0-trainval", nsweeps=10):
     if test:
         print(f"test sample: {len(train_nusc_infos)}")
         with open(
-            root_path / "infos_test_{:02d}sweeps_withvelo.pkl".format(nsweeps), "wb"
+            root_path / "infos_test_{:02d}sweeps_withvelo_filter_True.pkl".format(nsweeps), "wb"
         ) as f:
             pickle.dump(train_nusc_infos, f)
     else:
@@ -672,11 +675,11 @@ def create_nuscenes_infos(root_path, version="v1.0-trainval", nsweeps=10):
             f"train sample: {len(train_nusc_infos)}, val sample: {len(val_nusc_infos)}"
         )
         with open(
-            root_path / "infos_train_{:02d}sweeps_withvelo.pkl".format(nsweeps), "wb"
+            root_path / "infos_train_{:02d}sweeps_withvelo_filter_True.pkl".format(nsweeps), "wb"
         ) as f:
             pickle.dump(train_nusc_infos, f)
         with open(
-            root_path / "infos_val_{:02d}sweeps_withvelo.pkl".format(nsweeps), "wb"
+            root_path / "infos_val_{:02d}sweeps_withvelo_filter_True.pkl".format(nsweeps), "wb"
         ) as f:
             pickle.dump(val_nusc_infos, f)
 

--- a/det3d/datasets/nuscenes/nuscenes.py
+++ b/det3d/datasets/nuscenes/nuscenes.py
@@ -32,7 +32,7 @@ class NuScenesDataset(PointCloudDataset):
         self,
         info_path,
         root_path,
-        nsweeps=1,
+        nsweeps=0,  # catch sweep mistake 
         cfg=None,
         pipeline=None,
         class_names=None,

--- a/det3d/datasets/pipelines/loading.py
+++ b/det3d/datasets/pipelines/loading.py
@@ -49,6 +49,7 @@ def read_sweep(sweep):
     #                            dtype=np.float32).reshape([-1,
     #                                                       5])[:, :4].T
     points_sweep = read_file(str(sweep["lidar_path"])).T
+    points_sweep = remove_close(points_sweep, min_distance) # remove in its local coordinate 
 
     nbr_points = points_sweep.shape[1]
     if sweep["transform_matrix"] is not None:
@@ -56,7 +57,7 @@ def read_sweep(sweep):
             np.vstack((points_sweep[:3, :], np.ones(nbr_points)))
         )[:3, :]
     # points_sweep[3, :] /= 255
-    points_sweep = remove_close(points_sweep, min_distance)
+    
     curr_times = sweep["time_lag"] * np.ones((1, points_sweep.shape[1]))
 
     return points_sweep.T, curr_times.T

--- a/det3d/datasets/pipelines/preprocess.py
+++ b/det3d/datasets/pipelines/preprocess.py
@@ -199,7 +199,12 @@ class Preprocess(object):
             )
             gt_dict["gt_classes"] = gt_classes
 
-            gt_dict["gt_boxes"], points = prep.random_flip(gt_dict["gt_boxes"], points)
+            if res["type"] in ["NuScenesDataset"]:
+                # double flip gives 3 map improvement for pointppillars on nuScenes 
+                gt_dict["gt_boxes"], points = prep.random_flip_both(gt_dict["gt_boxes"], points)
+            else:
+                gt_dict["gt_boxes"], points = prep.random_flip(gt_dict["gt_boxes"], points)
+            
             gt_dict["gt_boxes"], points = prep.global_rotation(
                 gt_dict["gt_boxes"], points, rotation=self.global_rotation_noise
             )

--- a/det3d/models/bbox_heads/mg_head.py
+++ b/det3d/models/bbox_heads/mg_head.py
@@ -414,7 +414,7 @@ class MultiGroupHead(nn.Module):
         self.num_anchor_per_locs = [2 * n for n in num_classes]
 
         self.box_coder = box_coder
-        box_code_sizes = [box_coder.n_dim] * len(num_classes)
+        box_code_sizes = [box_coder.code_size] * len(num_classes)
 
         self.with_cls = with_cls
         self.with_reg = with_reg
@@ -424,7 +424,11 @@ class MultiGroupHead(nn.Module):
         self.encode_rad_error_by_sin = encode_rad_error_by_sin
         self.encode_background_as_zeros = encode_background_as_zeros
         self.use_sigmoid_score = use_sigmoid_score
-        self.box_n_dim = self.box_coder.n_dim
+        
+        # to work with the angle vector encoding 
+        self.box_n_dim = self.box_coder.code_size
+        self.anchor_dim = self.box_coder.n_dim
+        # self.box_n_dim = self.box_coder.n_dim
 
         self.loss_cls = build_loss(loss_cls)
         self.loss_reg = build_loss(loss_bbox)
@@ -650,7 +654,7 @@ class MultiGroupHead(nn.Module):
                 "cls_neg_loss": cls_neg_loss.detach().cpu(),
                 "dir_loss_reduced": dir_loss.detach().cpu()
                 if self.use_direction_classifier
-                else None,
+                else torch.tensor(0),
                 "cls_loss_reduced": cls_loss_reduced.detach().cpu().mean(),
                 "loc_loss_reduced": loc_loss_reduced.detach().cpu().mean(),
                 "loc_loss_elem": [elem.detach().cpu() for elem in loc_loss_elem],
@@ -714,7 +718,7 @@ class MultiGroupHead(nn.Module):
                 meta_list = example["metadata"]
 
             batch_task_anchors = example["anchors"][task_id].view(
-                batch_size, -1, self.box_n_dim
+                batch_size, -1, self.anchor_dim
             )
 
             if "anchors_mask" not in example:
@@ -1064,7 +1068,7 @@ class MultiGroupHead(nn.Module):
                 dtype = batch_reg_preds.dtype
                 device = batch_reg_preds.device
                 predictions_dict = {
-                    "box3d_lidar": torch.zeros([0, self.box_n_dim], dtype=dtype, device=device),
+                    "box3d_lidar": torch.zeros([0, self.anchor_dim], dtype=dtype, device=device),
                     "scores": torch.zeros([0], dtype=dtype, device=device),
                     "label_preds": torch.zeros(
                         [0], dtype=top_labels.dtype, device=device

--- a/det3d/models/readers/pillar_encoder.py
+++ b/det3d/models/readers/pillar_encoder.py
@@ -83,6 +83,7 @@ class PillarFeatureNet(nn.Module):
         self.name = "PillarFeatureNet"
         assert len(num_filters) > 0
 
+        self.num_input = num_input_features
         num_input_features += 5
         if with_distance:
             num_input_features += 1
@@ -117,7 +118,7 @@ class PillarFeatureNet(nn.Module):
         dtype = features.dtype
 
         # Find distance of x, y, and z from cluster center
-        features = features[:, :, :4]
+        # features = features[:, :, :self.num_input]
         points_mean = features[:, :, :3].sum(dim=1, keepdim=True) / num_voxels.type_as(
             features
         ).view(-1, 1, 1)
@@ -126,10 +127,10 @@ class PillarFeatureNet(nn.Module):
         # Find distance of x, y, and z from pillar center
         # f_center = features[:, :, :2]
         f_center = torch.zeros_like(features[:, :, :2])
-        f_center[:, :, 0] = f_center[:, :, 0] - (
+        f_center[:, :, 0] = features[:, :, 0] - (
             coors[:, 3].to(dtype).unsqueeze(1) * self.vx + self.x_offset
         )
-        f_center[:, :, 1] = f_center[:, :, 1] - (
+        f_center[:, :, 1] = features[:, :, 1] - (
             coors[:, 2].to(dtype).unsqueeze(1) * self.vy + self.y_offset
         )
 
@@ -189,6 +190,7 @@ class PointPillarsScatter(nn.Module):
 
             # Only include non-empty pillars
             batch_mask = coords[:, 0] == batch_itt
+
             this_coords = coords[batch_mask, :]
             indices = this_coords[:, 2] * self.nx + this_coords[:, 3]
             indices = indices.type(torch.long)

--- a/det3d/version.py
+++ b/det3d/version.py
@@ -1,4 +1,4 @@
 # GENERATED VERSION FILE
-# TIME: Fri Jan  3 23:05:12 2020
-__version__ = '1.0.rc0+678d807'
+# TIME: Fri Jun 19 17:20:56 2020
+__version__ = '1.0.rc0+2f20224'
 short_version = '1.0.rc0'

--- a/examples/cbgs/configs/nusc_all_vfev3_spmiddleresnetfhd_rpn2_mghead_syncbn.py
+++ b/examples/cbgs/configs/nusc_all_vfev3_spmiddleresnetfhd_rpn2_mghead_syncbn.py
@@ -4,7 +4,6 @@ import logging
 from det3d.builder import build_box_coder
 from det3d.utils.config_tool import get_downsample_factor
 
-# norm_cfg = dict(type='SyncBN', eps=1e-3, momentum=0.01)
 norm_cfg = None
 
 tasks = [
@@ -25,7 +24,7 @@ target_assigner = dict(
         dict(
             type="anchor_generator_range",
             sizes=[1.97, 4.63, 1.74],
-            anchor_ranges=[-50.4, -50.4, -0.95, 50.4, 50.4, -0.95],
+            anchor_ranges=[-51.2, -51.2, -0.95, 51.2, 51.2, -0.95],
             rotations=[0, 1.57],
             velocities=[0, 0],
             matched_threshold=0.6,
@@ -35,7 +34,7 @@ target_assigner = dict(
         dict(
             type="anchor_generator_range",
             sizes=[2.51, 6.93, 2.84],
-            anchor_ranges=[-50.4, -50.4, -0.40, 50.4, 50.4, -0.40],
+            anchor_ranges=[-51.2, -51.2, -0.40, 51.2, 51.2, -0.40],
             rotations=[0, 1.57],
             velocities=[0, 0],
             matched_threshold=0.55,
@@ -45,7 +44,7 @@ target_assigner = dict(
         dict(
             type="anchor_generator_range",
             sizes=[2.85, 6.37, 3.19],
-            anchor_ranges=[-50.4, -50.4, -0.225, 50.4, 50.4, -0.225],
+            anchor_ranges=[-51.2, -51.2, -0.225, 51.2, 51.2, -0.225],
             rotations=[0, 1.57],
             velocities=[0, 0],
             matched_threshold=0.5,
@@ -55,7 +54,7 @@ target_assigner = dict(
         dict(
             type="anchor_generator_range",
             sizes=[2.94, 10.5, 3.47],
-            anchor_ranges=[-50.4, -50.4, -0.085, 50.4, 50.4, -0.085],
+            anchor_ranges=[-51.2, -51.2, -0.085, 51.2, 51.2, -0.085],
             rotations=[0, 1.57],
             velocities=[0, 0],
             matched_threshold=0.55,
@@ -65,7 +64,7 @@ target_assigner = dict(
         dict(
             type="anchor_generator_range",
             sizes=[2.90, 12.29, 3.87],
-            anchor_ranges=[-50.4, -50.4, 0.115, 50.4, 50.4, 0.115],
+            anchor_ranges=[-51.2, -51.2, 0.115, 51.2, 51.2, 0.115],
             rotations=[0, 1.57],
             velocities=[0, 0],
             matched_threshold=0.5,
@@ -75,7 +74,7 @@ target_assigner = dict(
         dict(
             type="anchor_generator_range",
             sizes=[2.53, 0.50, 0.98],
-            anchor_ranges=[-50.4, -50.4, -1.33, 50.4, 50.4, -1.33],
+            anchor_ranges=[-51.2, -51.2, -1.33, 51.2, 51.2, -1.33],
             rotations=[0, 1.57],
             velocities=[0, 0],
             matched_threshold=0.55,
@@ -85,7 +84,7 @@ target_assigner = dict(
         dict(
             type="anchor_generator_range",
             sizes=[0.77, 2.11, 1.47],
-            anchor_ranges=[-50.4, -50.4, -1.085, 50.4, 50.4, -1.085],
+            anchor_ranges=[-51.2, -51.2, -1.085, 51.2, 51.2, -1.085],
             rotations=[0, 1.57],
             velocities=[0, 0],
             matched_threshold=0.5,
@@ -95,7 +94,7 @@ target_assigner = dict(
         dict(
             type="anchor_generator_range",
             sizes=[0.60, 1.70, 1.28],
-            anchor_ranges=[-50.4, -50.4, -1.18, 50.4, 50.4, -1.18],
+            anchor_ranges=[-51.2, -51.2, -1.18, 51.2, 51.2, -1.18],
             rotations=[0, 1.57],
             velocities=[0, 0],
             matched_threshold=0.5,
@@ -105,7 +104,7 @@ target_assigner = dict(
         dict(
             type="anchor_generator_range",
             sizes=[0.67, 0.73, 1.77],
-            anchor_ranges=[-50.4, -50.4, -0.935, 50.4, 50.4, -0.935],
+            anchor_ranges=[-51.2, -51.2, -0.935, 51.2, 51.2, -0.935],
             rotations=[0, 1.57],
             velocities=[0, 0],
             matched_threshold=0.6,
@@ -115,7 +114,7 @@ target_assigner = dict(
         dict(
             type="anchor_generator_range",
             sizes=[0.41, 0.41, 1.07],
-            anchor_ranges=[-50.4, -50.4, -1.285, 50.4, 50.4, -1.285],
+            anchor_ranges=[-51.2, -51.2, -1.285, 51.2, 51.2, -1.285],
             rotations=[0, 1.57],
             velocities=[0, 0],
             matched_threshold=0.6,
@@ -131,7 +130,7 @@ target_assigner = dict(
 )
 
 box_coder = dict(
-    type="ground_box3d_coder", n_dim=9, linear_dim=False, encode_angle_vector=False,
+    type="ground_box3d_coder", n_dim=9, linear_dim=False, encode_angle_vector=True,
 )
 
 # model settings
@@ -140,7 +139,6 @@ model = dict(
     pretrained=None,
     reader=dict(
         type="VoxelFeatureExtractorV3",
-        # type='SimpleVoxel',
         num_input_features=5,
         norm_cfg=norm_cfg,
     ),
@@ -159,7 +157,6 @@ model = dict(
         logger=logging.getLogger("RPN"),
     ),
     bbox_head=dict(
-        # type='RPNHead',
         type="MultiGroupHead",
         mode="3d",
         in_channels=sum([256, 256]),
@@ -176,17 +173,12 @@ model = dict(
         loss_bbox=dict(
             type="WeightedSmoothL1Loss",
             sigma=3.0,
-            code_weights=[1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 0.2, 0.2, 1.0],
+            code_weights=[1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 0.2, 0.2, 1.0, 1.0],
             codewise=True,
-            loss_weight=1.0,
+            loss_weight=0.25,
         ),
-        encode_rad_error_by_sin=True,
-        loss_aux=dict(
-            type="WeightedSoftmaxClassificationLoss",
-            name="direction_classifier",
-            loss_weight=0.2,
-        ),
-        direction_offset=0.785,
+        encode_rad_error_by_sin=False,
+        loss_aux=None,
     ),
 )
 
@@ -205,7 +197,7 @@ test_cfg = dict(
         use_rotate_nms=True,
         use_multi_class_nms=False,
         nms_pre_max_size=1000,
-        nms_post_max_size=80,
+        nms_post_max_size=83,
         nms_iou_threshold=0.2,
     ),
     score_threshold=0.1,
@@ -215,13 +207,13 @@ test_cfg = dict(
 
 # dataset settings
 dataset_type = "NuScenesDataset"
-n_sweeps = 10
-data_root = "/data/Datasets/nuScenes"
+nsweeps = 10
+data_root = "data/nuScenes"
 
 db_sampler = dict(
     type="GT-AUG",
     enable=False,
-    db_info_path="/data/Datasets/nuScenes/dbinfos_train_10sweeps_withvelo.pkl",
+    db_info_path="data/nuScenes/dbinfos_train_10sweeps_withvelo.pkl",
     sample_groups=[
         dict(car=2),
         dict(truck=3),
@@ -280,7 +272,7 @@ val_preprocessor = dict(
 )
 
 voxel_generator = dict(
-    range=[-50.4, -50.4, -5.0, 50.4, 50.4, 3.0],
+    range=[-51.2, -51.2, -5.0, 51.2, 51.2, 3.0],
     voxel_size=[0.1, 0.1, 0.2],
     max_points_in_voxel=10,
     max_voxel_num=60000,
@@ -304,19 +296,19 @@ test_pipeline = [
     dict(type="Reformat"),
 ]
 
-train_anno = "/data/Datasets/nuScenes/infos_train_10sweeps_withvelo.pkl"
-val_anno = "/data/Datasets/nuScenes/infos_val_10sweeps_withvelo.pkl"
+train_anno = "data/nuScenes/infos_train_10sweeps_withvelo_filter_True.pkl"
+val_anno = "data/nuScenes/infos_val_10sweeps_withvelo_filter_True.pkl"
 test_anno = None
 
 data = dict(
     samples_per_gpu=4,
-    workers_per_gpu=2,
+    workers_per_gpu=8,
     train=dict(
         type=dataset_type,
         root_path=data_root,
         info_path=train_anno,
         ann_file=train_anno,
-        n_sweeps=n_sweeps,
+        nsweeps=nsweeps,
         class_names=class_names,
         pipeline=train_pipeline,
     ),
@@ -326,7 +318,7 @@ data = dict(
         info_path=val_anno,
         test_mode=True,
         ann_file=val_anno,
-        n_sweeps=n_sweeps,
+        nsweeps=nsweeps,
         class_names=class_names,
         pipeline=test_pipeline,
     ),
@@ -335,7 +327,7 @@ data = dict(
         root_path=data_root,
         info_path=test_anno,
         ann_file=test_anno,
-        n_sweeps=n_sweeps,
+        nsweeps=nsweeps,
         class_names=class_names,
         pipeline=test_pipeline,
     ),
@@ -353,7 +345,7 @@ optimizer = dict(
 optimizer_config = dict(grad_clip=dict(max_norm=35, norm_type=2))
 # learning policy in training hooks
 lr_config = dict(
-    type="one_cycle", lr_max=0.001, moms=[0.95, 0.85], div_factor=10.0, pct_start=0.4,
+    type="one_cycle", lr_max=0.002, moms=[0.95, 0.85], div_factor=10.0, pct_start=0.4,
 )
 
 checkpoint_config = dict(interval=1)
@@ -362,7 +354,6 @@ log_config = dict(
     interval=5,
     hooks=[
         dict(type="TextLoggerHook"),
-        # dict(type='TensorboardLoggerHook')
     ],
 )
 # yapf:enable
@@ -371,8 +362,8 @@ total_epochs = 20
 device_ids = range(8)
 dist_params = dict(backend="nccl", init_method="env://")
 log_level = "INFO"
-work_dir = "/data/Outputs/MegDet3D_Outputs/SECOND_NUSC"
-load_from = None
-resume_from = None
-workflow = [("train", 1), ("val", 1)]
-# workflow = [('train', 1)]
+work_dir = './work_dirs/{}/'.format(__file__[__file__.rfind('/') + 1:-3])
+load_from = None 
+resume_from = None 
+workflow = [('train', 1)]
+

--- a/examples/point_pillars/configs/nusc_all_point_pillars_mghead_syncbn.py
+++ b/examples/point_pillars/configs/nusc_all_point_pillars_mghead_syncbn.py
@@ -4,7 +4,6 @@ import logging
 from det3d.builder import build_box_coder
 from det3d.utils.config_tool import get_downsample_factor
 
-# norm_cfg = dict(type='SyncBN', eps=1e-3, momentum=0.01)
 norm_cfg = None
 
 tasks = [
@@ -24,7 +23,7 @@ target_assigner = dict(
         dict(
             type="anchor_generator_range",
             sizes=[1.97, 4.63, 1.74],
-            anchor_ranges=[-50, -50, -0.95, 50, 50, -0.95],
+            anchor_ranges=[-51.2, -51.2, -0.95, 51.2, 51.2, -0.95],
             rotations=[0, 1.57],
             velocities=[0, 0],
             matched_threshold=0.6,
@@ -34,7 +33,7 @@ target_assigner = dict(
         dict(
             type="anchor_generator_range",
             sizes=[2.51, 6.93, 2.84],
-            anchor_ranges=[-50, -50, -0.40, 50, 50, -0.40],
+            anchor_ranges=[-51.2, -51.2, -0.40, 51.2, 51.2, -0.40],
             rotations=[0, 1.57],
             velocities=[0, 0],
             matched_threshold=0.55,
@@ -44,7 +43,7 @@ target_assigner = dict(
         dict(
             type="anchor_generator_range",
             sizes=[2.85, 6.37, 3.19],
-            anchor_ranges=[-50, -50, -0.225, 50, 50, -0.225],
+            anchor_ranges=[-51.2, -51.2, -0.225, 51.2, 51.2, -0.225],
             rotations=[0, 1.57],
             velocities=[0, 0],
             matched_threshold=0.5,
@@ -54,7 +53,7 @@ target_assigner = dict(
         dict(
             type="anchor_generator_range",
             sizes=[2.94, 10.5, 3.47],
-            anchor_ranges=[-50, -50, -0.085, 50, 50, -0.085],
+            anchor_ranges=[-51.2, -51.2, -0.085, 51.2, 51.2, -0.085],
             rotations=[0, 1.57],
             velocities=[0, 0],
             matched_threshold=0.55,
@@ -64,7 +63,7 @@ target_assigner = dict(
         dict(
             type="anchor_generator_range",
             sizes=[2.90, 12.29, 3.87],
-            anchor_ranges=[-50, -50, 0.115, 50, 50, 0.115],
+            anchor_ranges=[-51.2, -51.2, 0.115, 51.2, 51.2, 0.115],
             rotations=[0, 1.57],
             velocities=[0, 0],
             matched_threshold=0.5,
@@ -74,7 +73,7 @@ target_assigner = dict(
         dict(
             type="anchor_generator_range",
             sizes=[2.53, 0.50, 0.98],
-            anchor_ranges=[-50, -50, -1.33, 50, 50, -1.33],
+            anchor_ranges=[-51.2, -51.2, -1.33, 51.2, 51.2, -1.33],
             rotations=[0, 1.57],
             velocities=[0, 0],
             matched_threshold=0.55,
@@ -84,7 +83,7 @@ target_assigner = dict(
         dict(
             type="anchor_generator_range",
             sizes=[0.77, 2.11, 1.47],
-            anchor_ranges=[-50, -50, -1.085, 50, 50, -1.085],
+            anchor_ranges=[-51.2, -51.2, -1.085, 51.2, 51.2, -1.085],
             rotations=[0, 1.57],
             velocities=[0, 0],
             matched_threshold=0.5,
@@ -94,7 +93,7 @@ target_assigner = dict(
         dict(
             type="anchor_generator_range",
             sizes=[0.60, 1.70, 1.28],
-            anchor_ranges=[-50, -50, -1.18, 50, 50, -1.18],
+            anchor_ranges=[-51.2, -51.2, -1.18, 51.2, 51.2, -1.18],
             rotations=[0, 1.57],
             velocities=[0, 0],
             matched_threshold=0.5,
@@ -104,7 +103,7 @@ target_assigner = dict(
         dict(
             type="anchor_generator_range",
             sizes=[0.67, 0.73, 1.77],
-            anchor_ranges=[-50, -50, -0.935, 50, 50, -0.935],
+            anchor_ranges=[-51.2, -51.2, -0.935, 51.2, 51.2, -0.935],
             rotations=[0, 1.57],
             velocities=[0, 0],
             matched_threshold=0.6,
@@ -114,7 +113,7 @@ target_assigner = dict(
         dict(
             type="anchor_generator_range",
             sizes=[0.41, 0.41, 1.07],
-            anchor_ranges=[-50, -50, -1.285, 50, 50, -1.285],
+            anchor_ranges=[-51.2, -51.2, -1.285, 51.2, 51.2, -1.285],
             rotations=[0, 1.57],
             velocities=[0, 0],
             matched_threshold=0.6,
@@ -130,7 +129,7 @@ target_assigner = dict(
 )
 
 box_coder = dict(
-    type="ground_box3d_coder", n_dim=9, linear_dim=False, encode_angle_vector=False,
+    type="ground_box3d_coder", n_dim=9, linear_dim=False, encode_angle_vector=True,
 )
 
 # model settings
@@ -140,7 +139,10 @@ model = dict(
     reader=dict(
         type="PillarFeatureNet",
         num_filters=[64],
+        num_input_features=5,
         with_distance=False,
+        voxel_size=(0.2, 0.2, 8),
+        pc_range=(-51.2, -51.2, -5.0, 51.2, 51.2, 3.0),
         norm_cfg=norm_cfg,
     ),
     backbone=dict(type="PointPillarsScatter", ds_factor=1, norm_cfg=norm_cfg,),
@@ -156,7 +158,6 @@ model = dict(
         logger=logging.getLogger("RPN"),
     ),
     bbox_head=dict(
-        # type='RPNHead',
         type="MultiGroupHead",
         mode="3d",
         in_channels=sum([128, 128, 128]),  # this is linked to 'neck' us_num_filters
@@ -173,17 +174,13 @@ model = dict(
         loss_bbox=dict(
             type="WeightedSmoothL1Loss",
             sigma=3.0,
-            code_weights=[1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 0.2, 0.2, 1.0],
+            code_weights=[1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 0.2, 0.2, 1.0, 1.0],
             codewise=True,
-            loss_weight=1.0,
+            loss_weight=0.25,
         ),
-        encode_rad_error_by_sin=True,
-        loss_aux=dict(
-            type="WeightedSoftmaxClassificationLoss",
-            name="direction_classifier",
-            loss_weight=0.2,
-        ),
-        direction_offset=0.785,
+        encode_rad_error_by_sin=False,
+        loss_aux=None,
+        direction_offset=0
     ),
 )
 
@@ -201,7 +198,7 @@ test_cfg = dict(
         use_rotate_nms=True,
         use_multi_class_nms=False,
         nms_pre_max_size=1000,
-        nms_post_max_size=80,
+        nms_post_max_size=83,
         nms_iou_threshold=0.2,
     ),
     score_threshold=0.1,
@@ -211,13 +208,13 @@ test_cfg = dict(
 
 # dataset settings
 dataset_type = "NuScenesDataset"
-n_sweeps = 10
-data_root = "/data/Datasets/nuScenes"
+nsweeps = 10
+data_root = "data/nuScenes"
 
 db_sampler = dict(
     type="GT-AUG",
     enable=False,
-    db_info_path="/data/Datasets/nuScenes/dbinfos_train_10sweeps_withvelo.pkl",
+    db_info_path="data/nuScenes/dbinfos_train_10sweeps_withvelo.pkl",
     sample_groups=[
         dict(car=2),
         dict(truck=3),
@@ -276,10 +273,10 @@ val_preprocessor = dict(
 )
 
 voxel_generator = dict(
-    range=[-50, -50, -4.0, 50, 50, 2.0],
-    voxel_size=[0.25, 0.25, 6],
-    max_points_in_voxel=50,
-    max_voxel_num=60000,
+    range=[-51.2, -51.2, -5.0, 51.2, 51.2, 3.0],
+    voxel_size=[0.2, 0.2, 8],
+    max_points_in_voxel=20,
+    max_voxel_num=30000,
 )
 
 train_pipeline = [
@@ -289,7 +286,6 @@ train_pipeline = [
     dict(type="Voxelization", cfg=voxel_generator),
     dict(type="AssignTarget", cfg=train_cfg["assigner"]),
     dict(type="Reformat"),
-    # dict(type='PointCloudCollect', keys=['points', 'voxels', 'annotations', 'calib']),
 ]
 test_pipeline = [
     dict(type="LoadPointCloudFromFile", dataset=dataset_type),
@@ -300,19 +296,19 @@ test_pipeline = [
     dict(type="Reformat"),
 ]
 
-train_anno = "/data/Datasets/nuScenes/infos_train_10sweeps_withvelo.pkl"
-val_anno = "/data/Datasets/nuScenes/infos_val_10sweeps_withvelo.pkl"
+train_anno = "data/nuScenes/infos_train_10sweeps_withvelo_filter_True.pkl"
+val_anno = "data/nuScenes/infos_val_10sweeps_withvelo_filter_True.pkl"
 test_anno = None
 
 data = dict(
     samples_per_gpu=4,
-    workers_per_gpu=3,
+    workers_per_gpu=8,
     train=dict(
         type=dataset_type,
         root_path=data_root,
         info_path=train_anno,
         ann_file=train_anno,
-        n_sweeps=n_sweeps,
+        nsweeps=nsweeps,
         class_names=class_names,
         pipeline=train_pipeline,
     ),
@@ -320,9 +316,9 @@ data = dict(
         type=dataset_type,
         root_path=data_root,
         info_path=val_anno,
-        ann_file=val_anno,
         test_mode=True,
-        n_sweeps=n_sweeps,
+        ann_file=val_anno,
+        nsweeps=nsweeps,
         class_names=class_names,
         pipeline=test_pipeline,
     ),
@@ -331,7 +327,7 @@ data = dict(
         root_path=data_root,
         info_path=test_anno,
         ann_file=test_anno,
-        n_sweeps=n_sweeps,
+        nsweeps=nsweeps,
         class_names=class_names,
         pipeline=test_pipeline,
     ),
@@ -349,7 +345,7 @@ optimizer = dict(
 optimizer_config = dict(grad_clip=dict(max_norm=35, norm_type=2))
 # learning policy in training hooks
 lr_config = dict(
-    type="one_cycle", lr_max=0.001, moms=[0.95, 0.85], div_factor=10.0, pct_start=0.4,
+    type="one_cycle", lr_max=0.002, moms=[0.95, 0.85], div_factor=10.0, pct_start=0.4,  # change to 0.001 if you use 4 gpu
 )
 
 checkpoint_config = dict(interval=1)
@@ -367,7 +363,7 @@ total_epochs = 20
 device_ids = range(8)
 dist_params = dict(backend="nccl", init_method="env://")
 log_level = "INFO"
-work_dir = "/data/Outputs/Det3D_Outputs/Point_Pillars_NUSC"
+work_dir = './work_dirs/{}/'.format(__file__[__file__.rfind('/') + 1:-3])
 load_from = None
 resume_from = None
-workflow = [("train", 1), ("val", 1)]
+workflow = [('train', 1)]

--- a/tools/train.py
+++ b/tools/train.py
@@ -93,10 +93,11 @@ def main():
 
     if args.local_rank == 0:
         # copy important files to backup
-        backup_dir = os.path.join(cfg.work_dir, "det3d")
-        os.makedirs(backup_dir, exist_ok=True)
-        os.system("cp -r * %s/" % backup_dir)
-        logger.info(f"Backup source files to {cfg.work_dir}/det3d")
+        # backup_dir = os.path.join(cfg.work_dir, "det3d")
+        # os.makedirs(backup_dir, exist_ok=True)
+        # os.system("cp -r * %s/" % backup_dir)
+        # logger.info(f"Backup source files to {cfg.work_dir}/det3d")
+        pass # take too much space
 
     # set random seeds
     if args.seed is not None:

--- a/tools/train.py
+++ b/tools/train.py
@@ -93,11 +93,10 @@ def main():
 
     if args.local_rank == 0:
         # copy important files to backup
-        # backup_dir = os.path.join(cfg.work_dir, "det3d")
-        # os.makedirs(backup_dir, exist_ok=True)
-        # os.system("cp -r * %s/" % backup_dir)
-        # logger.info(f"Backup source files to {cfg.work_dir}/det3d")
-        pass # take too much space
+        backup_dir = os.path.join(cfg.work_dir, "det3d")
+        os.makedirs(backup_dir, exist_ok=True)
+        os.system("cp -r * %s/" % backup_dir)
+        logger.info(f"Backup source files to {cfg.work_dir}/det3d")
 
     # set random seeds
     if args.seed is not None:


### PR DESCRIPTION
This pr is trying to fix #80 #117  #55  #47.  

I get an improved baselines based on a forked version of det3d. And now I move some of the changes from my repo to the original one. 

PointPillars:

Performance Improvement:

before this commit:

```
mAP: 0.2992                                                                                                                                                                                                                                   
mATE: 0.4408                                                                                                                                                                                                                                  
mASE: 0.2704                                                                                                                                                                                                                                  
mAOE: 0.9446                                                                                                                                                                                                                                  
mAVE: 0.5465                                                                                                                                                                                                                                  
mAAE: 0.2187                                                                                                                                                                                                                                  
NDS: 0.4075                                                                                                                                                                                                                                   
Eval time: 194.4s                                                                                                                                                                                                                             
                                                                                                                                                                                                                                              
Per-class results:                                                                                                                                                                                                                            
Object Class    AP      ATE     ASE     AOE     AVE     AAE                                                                                                                                                                                   
car     0.732   0.236   0.161   0.788   0.261   0.213                                                                                                                                                                                         
truck   0.336   0.470   0.210   0.702   0.298   0.249                                                                                                                                                                                         
bus     0.395   0.518   0.188   0.953   0.851   0.266                                                                                                                                                                                         
trailer 0.197   0.697   0.221   0.698   0.222   0.183                                                                                                                                                                                         
construction_vehicle    0.038   0.802   0.467   1.328   0.138   0.328                                                                                                                                                                         
pedestrian      0.543   0.328   0.282   1.450   1.013   0.213                                                                                                                                                                                 
motorcycle      0.109   0.292   0.237   1.477   0.983   0.274
bicycle 0.005   0.290   0.265   1.043   0.605   0.023
traffic_cone    0.265   0.273   0.365   nan     nan     nan
barrier 0.372   0.503   0.308   0.063   nan     nan
```

After this commit:

```
mAP: 0.4179
mATE: 0.3630
mASE: 0.2636
mAOE: 0.3770
mAVE: 0.2877
mAAE: 0.1983
NDS: 0.5600
Eval time: 81.2s

Per-class results:
Object Class    AP      ATE     ASE     AOE     AVE     AAE
car     0.801   0.215   0.159   0.191   0.251   0.205
truck   0.457   0.411   0.205   0.159   0.192   0.223
bus     0.558   0.444   0.192   0.126   0.532   0.308
trailer 0.278   0.617   0.202   0.478   0.157   0.172
construction_vehicle    0.103   0.757   0.434   1.159   0.114   0.346
pedestrian      0.717   0.163   0.277   0.432   0.244   0.088
motorcycle      0.321   0.230   0.246   0.354   0.599   0.215
bicycle 0.053   0.193   0.265   0.376   0.213   0.030
traffic_cone    0.437   0.188   0.358   nan     nan     nan
barrier 0.455   0.411   0.297   0.117   nan     nan
Evaluation nusc: Nusc v1.0-trainval Evaluation
car Nusc dist AP@0.5, 1.0, 2.0, 4.0
67.75, 81.12, 85.15, 86.46 mean AP: 0.8012047920593498
truck Nusc dist AP@0.5, 1.0, 2.0, 4.0
23.71, 45.39, 54.92, 58.94 mean AP: 0.45739047966566226
construction_vehicle Nusc dist AP@0.5, 1.0, 2.0, 4.0
0.14, 5.21, 15.55, 20.37 mean AP: 0.10317209147626494
bus Nusc dist AP@0.5, 1.0, 2.0, 4.0
26.23, 54.24, 69.76, 72.88 mean AP: 0.5577483330153783
trailer Nusc dist AP@0.5, 1.0, 2.0, 4.0
5.09, 21.19, 35.53, 49.41 mean AP: 0.2780347493252949
barrier Nusc dist AP@0.5, 1.0, 2.0, 4.0
25.15, 45.56, 53.82, 57.33 mean AP: 0.45465027132389
motorcycle Nusc dist AP@0.5, 1.0, 2.0, 4.0
27.79, 32.90, 33.57, 33.96 mean AP: 0.3205635980429202
bicycle Nusc dist AP@0.5, 1.0, 2.0, 4.0
5.04, 5.26, 5.28, 5.45 mean AP: 0.05258777460814078
pedestrian Nusc dist AP@0.5, 1.0, 2.0, 4.0
68.81, 70.60, 72.70, 74.61 mean AP: 0.7168225670676128
traffic_cone Nusc dist AP@0.5, 1.0, 2.0, 4.0
39.71, 41.46, 44.16, 49.28 mean AP: 0.4365392833724403
```

Summary of changes
- bug fixes in pillar encoder (this boosts to 39.1 map / 50.2 nds)
-  cos / sin encoding in contrast to directional encoder (both the original repo and my current one can't get directional classifier work on nuScenes) -> (35.4 map / 52.4 nds)
- flip along x/y axis during training + regression weight from 1 to 0.25 + filtering zero points box during training -> (41.8 map / 56 nds)

In my repo(which will come out next Monday), I can get (45.5 map / 58.4 nds). The remained changes to my knowledge are:
- I use a heavier head with 3 conv-bn-relu. (this should matter the most) 
- I use l1 loss in place of smooth-l1 loss (minor accuracy difference)
- I initialize the final classification conv layer's bias to -2.19 (following focal paper, not sure how much improvement)

Changing to a heavier head requires rewriting mg_head so I didn't do this here. 

CBGS

results will be added once finish.(tomorrow night) 

To use this newest commit, you need to regenerate all those info files to filter out zero point boxes during training. The other should be the same (no need to regenerate the gt database if you already have one).

I will provide pre-trained models once the pr is merged. 